### PR TITLE
Prevent starting audio click on Firefox

### DIFF
--- a/morse.js
+++ b/morse.js
@@ -84,6 +84,7 @@ MorseNode.prototype.playChar = function(t, c) {
 
 MorseNode.prototype.playString = function(t, w) {
     w = w.toUpperCase();
+    t += this._dot; // add some silence to prevent starting click
     for(var i = 0; i < w.length; i++) {
         if(w[i] == ' ') {
             t += 3 * this._dot; // 3 dots from before, three here, and


### PR DESCRIPTION
Under Firefox I hear a click at the start of each played string, but adding a short amount of silence at the beginning fixes it.

This is on Firefox v63.0 under Ubuntu 18.04.